### PR TITLE
Update appvalidator/constants.py

### DIFF
--- a/appvalidator/constants.py
+++ b/appvalidator/constants.py
@@ -10,7 +10,7 @@ PACKAGE_PACKAGED_WEBAPP = 9
 
 SPIDERMONKEY_INSTALLATION = os.environ.get("SPIDERMONKEY_INSTALLATION")
 
-DEFAULT_WEBAPP_MRKT_URLS = ["https://marketplace.mozilla.org",
+DEFAULT_WEBAPP_MRKT_URLS = ["https://marketplace.firefox.com",
                             "https://marketplace-dev.allizom.org"]
 BUGZILLA_BUG = "https://bugzilla.mozilla.org/show_bug.cgi?id=%d"
 


### PR DESCRIPTION
change DEFAULT_WEBAPP_MRKT_URLS to check for marketplace.firefox.com instead (connected to bug 799563)
