### PR TITLE
Fix URL to icon page in style guide

### DIFF
--- a/appvalidator/specs/webapps.py
+++ b/appvalidator/specs/webapps.py
@@ -15,7 +15,7 @@ BANNED_ORIGINS = [
     "mozilla.org",
 ]
 
-STYLEGUIDE_URL = "http://www.mozilla.org/styleguide/products/firefox-os/icons/"
+STYLEGUIDE_URL = "http://www.mozilla.org/styleguide/products/firefox-os/"
 
 _FULL_PERMISSIONS = ("readonly", "readwrite", "readcreate", "createonly")
 


### PR DESCRIPTION
A 404 was being returned for http://www.mozilla.org/styleguide/products/firefox-os/icons/icons/
