### PR TITLE
replace PIL with pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ ndg-httpsclient==0.3.2
 pyasn1==0.1.7
 pyOpenSSL==0.13.1
 requests==2.0.0
-pillow==1.7.8
+Pillow==2.3.0


### PR DESCRIPTION
Looks like Travis CI isn't installing PIL because it's externally hosted and unverifiable. It's probably worth switching to something that's maintained. Looks like the tests pass, this should work... right?
