### PR TITLE
Use encoding from the response when getting remote data (bug 1012817)

### DIFF
--- a/appvalidator/testcases/webappbase.py
+++ b/appvalidator/testcases/webappbase.py
@@ -184,7 +184,7 @@ def try_get_resource(err, package, url, filename, resource_type="URL",
                 error="Resource too large",
                 description=["A requested resource returned too much data. "
                              "File sizes are limited to %dMB." %
-                                 (constants.MAX_RESOURCE_SIZE / 1204 / 1024),
+                                 (constants.MAX_RESOURCE_SIZE / 1024 / 1024),
                              "Requested resource: %s" % url],
                 filename=filename)
             return
@@ -194,6 +194,12 @@ def try_get_resource(err, package, url, filename, resource_type="URL",
         except AttributeError:
             # Some versions of requests don't support close().
             pass
+
+        if request.encoding:
+            # If a encoding was specified, decode raw data with it. Needed to
+            # properly feed unicode data to HTMLParser when content is in UTF-8
+            # for instance.
+            data = data.decode(request.encoding)
 
         http_cache[url] = data
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -54,6 +54,7 @@ def safe(func):
                 request = Mock()
                 request.text = "foo bar"
                 request.status_code = 200
+                request.encoding = 'UTF-8'
                 # The first bit is the return value. The second bit tells whatever
                 # is requesting the data that there's no more data.
                 request.raw.read.side_effect = [request.text, ""]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1012817

Otherwise the validator chokes on pages containing UTF-8 content (it tries to parse the `launch_page` mentioned in the manifest)
