### PR TITLE
Take inherited contexts into accounts for closure functions (bug 1081134)

### DIFF
--- a/appvalidator/testcases/javascript/nodedefinitions.py
+++ b/appvalidator/testcases/javascript/nodedefinitions.py
@@ -44,11 +44,16 @@ def _function(traverser, node):
     function expressions.
     """
 
+    current_contexts = traverser.contexts[:]
+
     def wrap():
         traverser.function_collection.append([])
         traverser._debug("THIS_PUSH")
         # Allow references to "this"
         traverser.this_stack.append(JSObject(traverser=traverser))
+
+        # inherit contexts from the current scope
+        traverser.contexts = current_contexts
 
         params = {}
         for param in node["params"]:


### PR DESCRIPTION
This prevents test_function_scope_block to fail, when run with Spidermonkey. The IIFE doesn't inherit the context from its outer function expression, so x is actually never found. Somehow, this was triggered for !expr but not for other kinds of expr.
