### PR TITLE
Convert \r\n line endings to \n before checking whitelist (bug 1088680)

### DIFF
--- a/appvalidator/testcases/content.py
+++ b/appvalidator/testcases/content.py
@@ -65,9 +65,11 @@ def test_packed_packages(err, package=None):
         except KeyError:
             pass
 
-        # Skip over whitelisted hashes.
-        if hashlib.sha256(file_data).hexdigest() in hashes_whitelist:
-            continue
+        # Skip over whitelisted hashes - only applies to .js files for now.
+        if name.endswith('.js'):
+            file_data = file_data.replace("\r\n", "\n")
+            if hashlib.sha256(file_data).hexdigest() in hashes_whitelist:
+                continue
 
         # Process the file.
         processed = _process_file(err, package, name, file_data)

--- a/tests/resources/content/error.js
+++ b/tests/resources/content/error.js
@@ -1,1 +1,3 @@
+// contains an error and windows-style line endings on purpose.
+// See TestContent.test_whitelist
 foo bar;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1088680
