### PR TITLE
Stop detecting mozTCPServerSocket, it doesn't exist (bug 1100712)

### DIFF
--- a/appvalidator/testcases/javascript/predefinedentities.py
+++ b/appvalidator/testcases/javascript/predefinedentities.py
@@ -81,7 +81,6 @@ NAVIGATOR = {
     u"mozGetGamepad": feature("GAMEPAD"),
     u"webkitGetGamepad": feature("GAMEPAD"),
     u"mozTCPSocket": feature("TCPSOCKET"),
-    u"mozTCPServerSocket": feature("TCPSOCKET"),
     u"mozInputMethod": feature("THIRDPARTY_KEYBOARD_SUPPORT"),
     u"mozMobileConnections": feature("NETWORK_INFO_MULTIPLE"),
 

--- a/tests/js/test_features.py
+++ b/tests/js/test_features.py
@@ -77,7 +77,6 @@ class TestNavigatorFeatures(FeatureTester):
         ("NOTIFICATION", "navigator.mozNotification.foo();"),
         ("ALARM", "navigator.mozAlarms.foo();"),
         ("TCPSOCKET", "var x = new navigator.mozTCPSocket();"),
-        ("TCPSOCKET", "var x = new navigator.mozTCPServerSocket();"),
         ("THIRDPARTY_KEYBOARD_SUPPORT",
          "var x = navigator.mozInputMethod.foo()"),
         ("NETWORK_INFO_MULTIPLE",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1100712

An instance of `TCPServerSocket` will be returned by calling `navigator.mozTCPSocket.listen()`, but `navigator.mozTCPServerSocket` does not exist.
