### PR TITLE
Detect navigator.getMobileIdAssertion() and precompile manifest option (bug 1098408)

### DIFF
--- a/appvalidator/specs/webapps.py
+++ b/appvalidator/specs/webapps.py
@@ -233,6 +233,7 @@ class WebappSpec(Spec):
             },
             "precompile": {
                 "expected_type": list,
+                "process": lambda s: s.process_precompile,
             },
             "csp": {"expected_type": types.StringTypes,
                     "not_empty": True},
@@ -703,6 +704,9 @@ class WebappSpec(Spec):
                                      banned_origin,
                                  "Found origin: %s" % node,
                                  self.MORE_INFO])
+
+    def process_precompile(self, node):
+        self.err.feature_profile.add('PRECOMPILE_ASMJS')
 
     def parse(self, data):
         if isinstance(data, types.StringTypes):

--- a/appvalidator/testcases/javascript/predefinedentities.py
+++ b/appvalidator/testcases/javascript/predefinedentities.py
@@ -84,7 +84,7 @@ NAVIGATOR = {
     u"mozTCPServerSocket": feature("TCPSOCKET"),
     u"mozInputMethod": feature("THIRDPARTY_KEYBOARD_SUPPORT"),
     u"mozMobileConnections": feature("NETWORK_INFO_MULTIPLE"),
-
+    u"getMobileIdAssertion": feature("MOBILE_ID"),
     u"getUserMedia": entity("getUserMedia"),
 }
 

--- a/tests/js/test_features.py
+++ b/tests/js/test_features.py
@@ -74,6 +74,7 @@ class TestNavigatorFeatures(FeatureTester):
         ("FM", "navigator.mozFMRadio();"),
         ("SMS", "navigator.mozSms.foo();"),
         ("GAMEPAD", "navigator.getGamepad();"),
+        ("MOBILE_ID", "navigator.getMobileIdAssertion();"),
         ("NOTIFICATION", "navigator.mozNotification.foo();"),
         ("ALARM", "navigator.mozAlarms.foo();"),
         ("TCPSOCKET", "var x = new navigator.mozTCPSocket();"),

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1028,3 +1028,8 @@ class TestWebapps(WebappBaseTestCase):
         self.data["precompile"] = {"foo.js": True}
         self.analyze()
         self.assert_failed(with_errors=True)
+
+    def test_precompile_feature(self):
+        self.analyze()
+        self.assert_silent()
+        self.assert_has_feature('PRECOMPILE_ASMJS')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1098408
