### PR TITLE
Bump requirements (follow what zamboni uses) (bug 846349)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 cssutils==0.9.7
 Fabric==0.9.0
-nose==1.0.0
-argparse==1.1
--e git://github.com/mattbasta/fastchardet#egg=fastchardet
-mock==1.0b1
+nose==1.3.3
+argparse==1.2.1
+fastchardet==0.2.0
+mock==1.0.1
 ndg-httpsclient==0.3.2
 pyasn1==0.1.7
 pyOpenSSL==0.13.1


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=846349

(Some are still behind the latest version, but at least it's coherent with zamboni now)