### PR TITLE
Handle PrototypeMutation in ObjectExpression (bug 1181186)

### DIFF
--- a/appvalidator/testcases/javascript/nodedefinitions.py
+++ b/appvalidator/testcases/javascript/nodedefinitions.py
@@ -196,11 +196,23 @@ def ArrayExpression(traverser, node):
 def ObjectExpression(traverser, node):
     var = JSObject(traverser=traverser)
     for prop in node["properties"]:
-        key = prop["key"]
-        var.set(key["value" if key["type"] == "Literal" else "name"],
-                traverser.traverse_node(prop["value"]),
-                traverser=traverser, ignore_setters=True)
-        # TODO: Observe "kind"
+        if prop["type"] == "PrototypeMutation":
+            var_name = "prototype"
+        else:
+            key = prop["key"]
+            if key["type"] == "Literal":
+                var_name = key["value"]
+            elif isinstance(key["name"], basestring):
+                var_name = key["name"]
+            else:
+                if "property" in key["name"]:
+                    name = key["name"]
+                else:
+                    name = {"property": key["name"]}
+                var_name = _get_member_exp_property(traverser, name)
+
+        var_value = traverser.traverse_node(prop["value"])
+        var.set(var_name, var_value, traverser)
 
     return var
 

--- a/tests/js/test_prototypes.py
+++ b/tests/js/test_prototypes.py
@@ -1,0 +1,18 @@
+from nose.tools import eq_
+
+from js_helper import skip_on_acorn, TestCase
+
+
+class TestProtoAssignment(TestCase):
+
+    @skip_on_acorn
+    def test__proto__asignment(self):
+        """
+        Make sure that setting __proto__ doesn't traceback.
+        """
+
+        self.setUp()
+        self.run_script('''
+            var obj = {foo: 'bar', __proto__: null};
+        ''')
+        self.assert_silent()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1181186

r? @diox @kmaglione 

I just ported over the changes Kris made to the amo-validator for computed properties. [amo-validator code](https://github.com/mozilla/amo-validator/blob/7b0a39e5c49e0352d1a6869658cf0d7048df44d6/validator/testcases/javascript/actions.py#L333-L351), [commit](https://github.com/mozilla/amo-validator/commit/5e195eadeca64b2adb8bc0f2c2ed796b531bfa80)