### PR TITLE
Fix permission checking (bug 1178810)

### DIFF
--- a/appvalidator/specs/webapps.py
+++ b/appvalidator/specs/webapps.py
@@ -730,7 +730,7 @@ class WebappSpec(Spec):
         requested_permissions = set()
 
         for permission, per_node in node.items():
-            if permission in PRERELEASE_PERMISSIONS:
+            if permission in ALL_PERMISSIONS:
                 requested_permissions.add(permission)
 
             if permission not in self.PERMISSIONS_ACCESS:
@@ -761,8 +761,6 @@ class WebappSpec(Spec):
                                          self.PERMISSIONS_ACCESS[permission]),
                                  "Found value: %s" % access_value,
                                  self.MORE_INFO])
-
-            requested_permissions.add(permission)
 
         self.err.save_resource("permissions", list(requested_permissions))
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -155,6 +155,12 @@ class TestCase(object):
             '"%s" not found in feature profile (%s)' % (
                 name, ', '.join(self.err.feature_profile)))
 
+    def assert_has_permission(self, name):
+        permissions = self.err.get_resource("permissions")
+        assert name in permissions, (
+            '"%s" not found in permissions (%s)' % (
+                name, ', '.join(permissions)))
+
 
 class MockZipFile:
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1134,12 +1134,17 @@ class TestWebapps(WebappBaseTestCase):
         self.set_permissions()
         self.analyze()
         self.assert_silent()
+        for perm in appvalidator.constants.ALL_PERMISSIONS:
+            self.assert_has_permission(perm)
 
     def test_permissions_extra_invalid(self):
         self.set_permissions()
         self.data["permissions"]["foo"] = {"description": "lol"}
         self.analyze()
         self.assert_failed(with_errors=True)
+        assert 'foo' not in self.err.get_resource("permissions")
+        for perm in appvalidator.constants.ALL_PERMISSIONS:
+            self.assert_has_permission(perm)
 
     def test_permissions_missing_desc(self):
         self.set_permissions()
@@ -1246,7 +1251,6 @@ class TestWebapps(WebappBaseTestCase):
         ]
         self.analyze()
         self.assert_failed(with_errors=True)
-
 
     def test_redirects_missing_nodes(self):
         self.data['redirects'] = [


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1178810

It has never worked properly except for prerelease permissions and permissions that required an 'access' value. For the rest, because we `continue`d before adding the permission to the set, we never
checked or returned them to the caller.