### PR TITLE
bug 1238373 - permission to upload a homescreen

### DIFF
--- a/appvalidator/constants.py
+++ b/appvalidator/constants.py
@@ -44,7 +44,7 @@ PERMISSIONS = {
         'device-storage:videos', 'device-storage:music',
         'device-storage:sdcard', 'feature-detection', 'input', 'mobileid',
         'mobilenetwork', 'nfc', 'speaker-control', 'systemXHR', 'tcp-socket',
-        'udp-socket',
+        'udp-socket', 'homescreen-webapps-manage'
     ]),
     'certified': set([
         'attention', 'audio-channel-ringer', 'audio-channel-telephony',


### PR DESCRIPTION
Bug 1238373 - Add support for the'homescreen-webapps-manage' permission in the app manifest for the validator 
